### PR TITLE
Remove Fapp::Fapp() con/destructor.

### DIFF
--- a/lib/FANETLORA/radio/fmac.h
+++ b/lib/FANETLORA/radio/fmac.h
@@ -144,8 +144,6 @@ public:
 class Fapp
 {
 public:
-	Fapp() { }
-	virtual ~Fapp() { }
 
 	/* device -> air */
 	virtual bool is_broadcast_ready(int num_neighbors) = 0;


### PR DESCRIPTION
Constructors can't be virtual, but without an implementation a debug build fails with:

.pio/build/nopsRam/src/main.cpp.o:(.literal._ZN9FanetLoraD5Ev[FanetLora::~FanetLora()]+0x1c): undefined reference to `vtable for Fapp'

Let the compiler handle this....