### PR TITLE
Add support for barometer BMP3xx

### DIFF
--- a/lib/Baro/Baro.cpp
+++ b/lib/Baro/Baro.cpp
@@ -16,6 +16,42 @@ Baro::Baro(){
   //FilterAlt(1.0f, 1.0f, 0.01f);
 }
 
+bool Baro::initBMP3XX(void){
+  uint8_t error;
+  bool ret = false;
+  for (sensorAdr = 0x76; sensorAdr <= 0x77; sensorAdr++)
+  {
+    log_i("check device at address 0x%X !",sensorAdr);
+    pI2c->beginTransmission(sensorAdr);
+    error = pI2c->endTransmission();
+    if (error == 0){
+      log_i("I2C device found at address 0x%X !",sensorAdr);
+      ret = bmp3xx.begin_I2C(sensorAdr,pI2c);
+      log_i("check sensor on adr 0x%X ret=%d",sensorAdr,ret);
+      if (ret){
+        log_i("found sensor BMP3XX on adr 0x%X",sensorAdr);
+        break;
+      }
+    }
+    else
+    {
+      log_i("Checking device at address 0x%X returned error %X", sensorAdr, error);
+    }
+  }
+  
+  if (!ret) return false;
+  
+  uint8_t chipId = bmp3xx.chipID();
+  if ((chipId == BMP3_CHIP_ID) || (chipId == BMP390_CHIP_ID))
+  log_i("found sensor BMP3xx on adr 0x%X",sensorAdr);
+  sensorType = SENSORTYPE_BMP3XX; //init to no sensor connected
+  //sensor found --> set sampling
+  bmp3xx.setPressureOversampling(BMP3_OVERSAMPLING_8X);
+  bmp3xx.setTemperatureOversampling(BMP3_NO_OVERSAMPLING);
+  bmp3xx.setIIRFilterCoeff(BMP3_IIR_FILTER_DISABLE);
+  return true;
+}
+
 bool Baro::initBME280(void){
   uint8_t error;
   sensorAdr = 0x76;
@@ -185,7 +221,7 @@ bool Baro::calibrate(bool bInit,uint8_t* calibstate){
     preferences.putFloat("axScale", ax_scale);
     preferences.putFloat("ayScale", ay_scale);
     preferences.putFloat("azScale", az_scale);
-    
+
     logData.temp = getMpuTemp();
     log_i("temp=%.1f",logData.temp);
     preferences.putFloat("t[0]",logData.temp); //set temp from calibrating
@@ -525,6 +561,9 @@ uint8_t Baro::begin(TwoWire *pi2c){
   }else if (initMS5611()){
     log_i("found MS5611");
     ret = 2; //GY-86-Board
+  }else if (initBMP3XX()){
+    log_i("found BMP3xx");
+    ret = 3; //BMP3xx;
   }else{
     return 0;
   }
@@ -943,6 +982,39 @@ void Baro::runBME280(uint32_t tAct){
   }
 }
 
+void Baro::runBMP3XX(uint32_t tAct){
+  static uint32_t tOld = millis();
+  //if ((tAct - tOld) >= 10)
+  {
+    if (!bmp3xx.performReading()) {
+      log_e("Failed to perform reading :(");
+      initBMP3XX();
+      return;
+    }
+    if (countReadings < 10){
+      countReadings++;
+    }else{
+      if (countReadings == 10){
+        logData.newData = 0x80;
+        countReadings++;
+      }
+      logData.temp = static_cast<float>(bmp3xx.temperature);
+      logData.pressure = static_cast<float>(bmp3xx.pressure);
+      logData.altitude = ms5611.getAltitude(bmp3xx.pressure);
+      logData.loopTime = tAct - tOld;
+      calcClimbing();
+      if (logData.newData == 0x80){
+        logData.newData = 0;
+        bNewValues = false;
+      }else{
+        copyValues();        
+        logData.newData = 1;
+        bNewValues = true;
+      }
+    }
+  }
+}
+
 void Baro::run(void){
   //static uint32_t tOld;  
   uint32_t tAct = millis();
@@ -951,6 +1023,8 @@ void Baro::run(void){
     runMS5611(tAct);
   }else if (sensorType == SENSORTYPE_BME280){
     runBME280(tAct);
+  }else if (sensorType == SENSORTYPE_BMP3XX){
+    runBMP3XX(tAct);
   }
 
   #ifdef BARO_DEBUG

--- a/lib/Baro/Baro.h
+++ b/lib/Baro/Baro.h
@@ -1,5 +1,3 @@
-
-
 /*!
  * @file Baro.h
  *
@@ -21,6 +19,7 @@
 #include <math.h>
 #include <kalmanvert.h>
 #include <Adafruit_BME280.h>
+#include <Adafruit_BMP3XX.h>
 #include <Preferences.h>
 #include "helper_3dmath.h"
 #include "InterpolationLib.h"
@@ -41,6 +40,7 @@
 #define SENSORTYPE_NONE 0
 #define SENSORTYPE_MS5611 1
 #define SENSORTYPE_BME280 2
+#define SENSORTYPE_BMP3XX 3
 
 class Baro {
     struct udpData{
@@ -94,8 +94,10 @@ private:
     void copyValues(void);
     bool initMS5611(void);
     bool initBME280(void);
+    bool initBMP3XX(void);
     void runMS5611(uint32_t tAct);
     void runBME280(uint32_t tAct);
+    void runBMP3XX(uint32_t tAct);
     bool mpuDrdy(void);
     float getGravityCompensatedAccel(float temp);
     void scaleAccel(VectorInt16 *accel,float temp);
@@ -107,6 +109,7 @@ private:
     uint8_t sensorAdr;
     bool bNewValues;
     Adafruit_BME280 bme;
+    Adafruit_BMP3XX bmp3xx;
     MS5611 ms5611;
     HMC5883L mag;
     udpData logData;

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,6 +24,8 @@ build_flags =  -D CORE_DEBUG_LEVEL=3
 lib_deps =
    h2zero/NimBLE-Arduino @ ~1.4.1
    paulstoffregen/OneWire @ ~2.3.7
+   adafruit/Adafruit BusIO @ ^1.14.1
+   adafruit/Adafruit BMP3XX Library @ ^2.1.2
 board_build.partitions = min_spiffs.csv
 monitor_speed = 115200
 upload_speed = 921600

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,6 +75,7 @@
 #include "driver/rtc_io.h"
 #endif
 
+#define uS_TO_S_FACTOR 1000000uL  /* Conversion factor for micro seconds to seconds */
 
 #ifdef GSMODULE
 
@@ -83,7 +84,6 @@
 #include <WeatherUnderground.h>
 #include <Windy.h>
 
-#define uS_TO_S_FACTOR 1000000uL  /* Conversion factor for micro seconds to seconds */
 //#define uS_TO_ms_FACTOR 1000000uL  /* Conversion factor for micro seconds to seconds */
 //#define TIME_TO_SLEEP  5uL //5 seconds
 //#define TIME_TO_SLEEP  1800uL //1/2 Stunde
@@ -398,12 +398,15 @@ void handleUpdate(uint32_t tAct);
 void printChipInfo(void);
 void setAllTime(tm &timeinfo);
 void checkExtPowerOff(uint32_t tAct);
+#ifdef GSMODULE
 void sendFanetWeatherData2WU(FanetLora::weatherData *weatherData,uint8_t wuIndex);
 void sendFanetWeatherData2WI(FanetLora::weatherData *weatherData,uint8_t wiIndex);
+#endif
 #ifdef AIRMODULE
 bool setupUbloxConfig(void);
 #endif
 
+#ifdef GSMODULE
 void sendFanetWeatherData2WU(FanetLora::weatherData *weatherData,uint8_t wuIndex){
   if ((status.bInternetConnected) && (status.bTimeOk)){
     WeatherUnderground wu;
@@ -450,6 +453,7 @@ void sendFanetWeatherData2WI(FanetLora::weatherData *weatherData,uint8_t wiIndex
     wi.sendData(setting.FntWiUpload[wiIndex].ID,setting.FntWiUpload[wiIndex].KEY,&wiData);
   }
 }
+#endif
 
 void readFuelSensor(uint32_t tAct){
   static uint32_t tRead = millis();
@@ -4614,6 +4618,8 @@ void taskStandard(void *pvParameters){
         }
       }
     }
+
+#ifdef GSMODULE
     FanetLora::weatherData weatherData;
     if (fanet.getWeatherData(&weatherData)){
       //check if we forward the weather-data to WU
@@ -4653,7 +4659,8 @@ void taskStandard(void *pvParameters){
         }
         
       }
-    }    
+    }
+#endif    
     if (fanet.getTrackingData(&tFanetData)){
       //log_i("new Tracking-Data");
       if (tFanetData.type == 0x11){ //online-tracking


### PR DESCRIPTION
Add support for Bosch Sensotec BMP380 and BMP390 barometer using Adafruit library.

BMP3XX are successors to the BMP280. They are widely used in (consumer) hardware and provide a better accuracy compared to the barometers used in this project so far.