### PR TITLE
Fix display of GxAirCom  in Safari OSX/iPhone/iPad

### DIFF
--- a/lib/ESPAsyncWebServer-master/src/WebResponses.cpp
+++ b/lib/ESPAsyncWebServer-master/src/WebResponses.cpp
@@ -524,18 +524,14 @@ AsyncFileResponse::AsyncFileResponse(FS &fs, const String& path, const String& c
   else
     _contentType = contentType;
 
-  int filenameStart = path.lastIndexOf('/') + 1;
-  char buf[26+path.length()-filenameStart];
-  char* filename = (char*)path.c_str() + filenameStart;
-
   if(download) {
+    int filenameStart = path.lastIndexOf('/') + 1;
+    char buf[26+path.length()-filenameStart];
+    char* filename = (char*)path.c_str() + filenameStart;
     // set filename and force download
     snprintf(buf, sizeof (buf), "attachment; filename=\"%s\"", filename);
-  } else {
-    // set filename and force rendering
-    snprintf(buf, sizeof (buf), "inline; filename=\"%s\"", filename);
+    addHeader("Content-Disposition", buf);
   }
-  addHeader("Content-Disposition", buf);
 }
 
 AsyncFileResponse::AsyncFileResponse(File content, const String& path, const String& contentType, bool download, AwsTemplateProcessor callback): AsyncAbstractResponse(callback){
@@ -557,16 +553,15 @@ AsyncFileResponse::AsyncFileResponse(File content, const String& path, const Str
   else
     _contentType = contentType;
 
-  int filenameStart = path.lastIndexOf('/') + 1;
-  char buf[26+path.length()-filenameStart];
-  char* filename = (char*)path.c_str() + filenameStart;
-
   if(download) {
+    int filenameStart = path.lastIndexOf('/') + 1;
+    char buf[26+path.length()-filenameStart];
+    char* filename = (char*)path.c_str() + filenameStart;
     snprintf(buf, sizeof (buf), "attachment; filename=\"%s\"", filename);
+    addHeader("Content-Disposition", buf);
   } else {
-    snprintf(buf, sizeof (buf), "inline; filename=\"%s\"", filename);
+    //snprintf(buf, sizeof (buf), "inline; filename=\"%s\"", filename);
   }
-  addHeader("Content-Disposition", buf);
 }
 
 size_t AsyncFileResponse::_fillBuffer(uint8_t *data, size_t len){

--- a/lib/ESPAsyncWebServer-master/src/WebResponses.cpp
+++ b/lib/ESPAsyncWebServer-master/src/WebResponses.cpp
@@ -559,8 +559,6 @@ AsyncFileResponse::AsyncFileResponse(File content, const String& path, const Str
     char* filename = (char*)path.c_str() + filenameStart;
     snprintf(buf, sizeof (buf), "attachment; filename=\"%s\"", filename);
     addHeader("Content-Disposition", buf);
-  } else {
-    //snprintf(buf, sizeof (buf), "inline; filename=\"%s\"", filename);
   }
 }
 


### PR DESCRIPTION
For iPad and iPhone I noticed that when I try to open the webpages of GxAirCom on these devices the pages get's downloaded instead of displayed.

This is because the `Content-Disposition` is set to  `inline: filename="<somefile>.html.gz` so apparently Safari thinks this is a '.gz' file that cannot be displayed. Event though `Content-Type` is `text/html`. I think the jury is out if how this should be interpreted... 

That said, the fix is in in `ESPAsyncWebServer`, this library seems to be unmaintained (see https://github.com/me-no-dev/ESPAsyncWebServer) , it also did not had any options to set our own  `Content-Disposition` so it seemed for to add the fix in that library..

The fix is simply to remove the `Content-Disposition` for files that should be displayed.