### PR TITLE
Improve flarm dataport and handle online tracking flag

### DIFF
--- a/lib/FANETLORA/FanetLora.cpp
+++ b/lib/FANETLORA/FanetLora.cpp
@@ -393,6 +393,7 @@ void FanetLora::insertDataToNeighbour(uint32_t devId, trackingData *Data){
   neighbours[index].rssi = Data->rssi;
   neighbours[index].type = Data->type;
   neighbours[index].addressType = Data->addressType;
+  neighbours[index].OnlineTracking = Data->OnlineTracking;
 }
 
 void FanetLora::clearNeighboursWeather(uint32_t tAct){
@@ -1239,7 +1240,7 @@ int FanetLora::serialize_GroundTracking(trackingData *Data,uint8_t*& buffer){
 	Frame::coord2payload_absolut(Data->lat, Data->lon, buffer);
 
 	/* state */
-	buffer[6] = (state&0x0F)<<4 | (!!doOnlineTracking);
+	buffer[6] = (state&0x0F)<<4 | (Data->OnlineTracking);
 
 	return FANET_LORA_TYPE7_SIZE;
 }
@@ -1256,7 +1257,7 @@ int FanetLora::serialize_tracking(trackingData *Data,uint8_t*& buffer){
 	else
 		((uint16_t*)buffer)[3] = alt;
 	/* online tracking */
-	((uint16_t*)buffer)[3] |= !!doOnlineTracking<<15;
+	((uint16_t*)buffer)[3] |= Data->OnlineTracking<<15;
 	/* aircraft type */
 	((uint16_t*)buffer)[3] |= (Data->aircraftType&0x7)<<12;
 
@@ -1374,6 +1375,7 @@ void FanetLora::setMyTrackingData(trackingData *tData,float geoidAlt,uint32_t pp
     _myData.lat = tData->lat;
     _myData.lon = tData->lon;
     _myData.speed = tData->speed;
+    _myData.OnlineTracking = tData->OnlineTracking;
     fmac.lat = _myData.lat;
     fmac.lon = _myData.lon;
     fmac.geoidAlt = geoidAlt;

--- a/lib/FANETLORA/FanetLora.h
+++ b/lib/FANETLORA/FanetLora.h
@@ -216,6 +216,7 @@ public:
     int rssi; //rssi
     uint8_t type; //tracking-type (11... online tracking 7X .... ground tracking)s
     uint8_t addressType;
+    bool OnlineTracking;
   } neighbour;
 
   typedef struct {
@@ -286,7 +287,6 @@ public:
   trackingData _myData;
   bool autobroadcast = false; //autobroadcast
   bool autoSendName = false; //send Fanet-name
-  bool doOnlineTracking = true; //online-tracking
   bool onGround = false;
   status_t state = hiking;
 

--- a/lib/FANETLORA/radio/fmac.cpp
+++ b/lib/FANETLORA/radio/fmac.cpp
@@ -232,21 +232,20 @@ int serialize_legacyTracking(ufo_t *Data,uint8_t*& buffer){
 	return 11; //FANET_LORA_TYPE1_SIZE - 2;
 }
 
-
-uint8_t FanetMac::getAddressType(uint8_t manuId){
-	//  GxAircom            Skytraxx          XCTracer
-	if (manuId == 0x08 || manuId == 0x11 || manuId == 0x20 || manuId == 0xDD || manuId == 0xDE || manuId == 0xDF){
-			return 2; //address type FLARM
-			//log_i("address=%s Flarm",devId.c_str());
-	/*
-	}else if (manuId == 0x08){
-			return 3; //address type OGN        
-			//log_i("address=%s OGN",devId.c_str());
-	*/
-	}else{
-			return 0; //address type unknown
-	}
-}
+// uint8_t FanetMac::getAddressType(uint8_t manuId){
+// 	//  GxAircom            Skytraxx          XCTracer
+// 	if (manuId == 0x08 || manuId == 0x11 || manuId == 0x20 || manuId == 0xDD || manuId == 0xDE || manuId == 0xDF){
+// 			return 2; //address type FLARM
+// 			//log_i("address=%s Flarm",devId.c_str());
+// 	/*
+// 	}else if (manuId == 0x08){
+// 			return 3; //address type OGN        
+// 			//log_i("address=%s OGN",devId.c_str());
+// 	*/
+// 	}else{
+// 			return 0; //address type unknown
+// 	}
+// }
 
 void FanetMac::sendUdpData(const uint8_t *buffer,int len){
 	if ((WiFi.status() == WL_CONNECTED) || (WiFi.softAPgetStationNum() > 0)){ //connected to wifi or a client is connected to me
@@ -480,7 +479,8 @@ void FanetMac::frameReceived(int length)
 		//frm->timeStamp = now;
 		frm->timeStamp = uint32_t(now());
 		//log_i("%d",frm->timeStamp);
-		frm->AddressType = getAddressType(frm->src.manufacturer) + 0x80; //set highest Bit, so we know, that it was a Fanet-MSG
+		//frm->AddressType = getAddressType(frm->src.manufacturer) + 0x80; //set highest Bit, so we know, that it was a Fanet-MSG
+		frm->AddressType = 2 + 0x80; //Fanet is always type 2, set highest Bit, so we know, that it was a Fanet-MSG
 		rxFntCount++;
   }  
 	frm->rssi = rssi;

--- a/lib/FANETLORA/radio/fmac.cpp
+++ b/lib/FANETLORA/radio/fmac.cpp
@@ -207,7 +207,7 @@ int serialize_legacyTracking(ufo_t *Data,uint8_t*& buffer){
 	else
 		((uint16_t*)buffer)[3] = alt;
 	/* online tracking */
-	((uint16_t*)buffer)[3] |= !Data->stealth<<15;
+	((uint16_t*)buffer)[3] |= !(Data->stealth || Data->no_track)<<15;
 	/* aircraft type */
 	//((uint16_t*)buffer)[3] |= (LP_Flarm2FanetAircraft((eFlarmAircraftType)Data->aircraft_type)&0x7)<<12;
 	((uint16_t*)buffer)[3] |= (Flarm2FanetAircraft((eFlarmAircraftType)Data->aircraft_type)&0x7)<<12;

--- a/lib/FANETLORA/radio/fmac.h
+++ b/lib/FANETLORA/radio/fmac.h
@@ -243,7 +243,7 @@ private:
 	void handleTxLegacy();
 	void handleRx();
 	void switchMode(uint8_t mode,bool bStartReceive = true);
-	uint8_t getAddressType(uint8_t manuId);
+	//uint8_t getAddressType(uint8_t manuId);
   //void coord2payload_absolut(float lat, float lon, uint8_t *buf);
 
 	bool isNeighbor(MacAddr addr);

--- a/lib/FLARM/FlarmDataPort.cpp
+++ b/lib/FLARM/FlarmDataPort.cpp
@@ -84,7 +84,7 @@ int FlarmDataPort::writeFlarmData(char *buffer, size_t size,FlarmtrackingData *m
     Serial.print("relNorth=");Serial.println(relNorth);
     Serial.print("relEast=");Serial.println(relEast);
     */
-    snprintf(buffer,size,"$PFLAA,0,%d,%d,%d,%d,%s,%d,0,%.01f,%.01f,%X",(int32_t)round(relNorth),(int32_t)round(relEast),(int32_t)round(relVert),movePilotData->addressType, movePilotData->DevId.c_str(),(int32_t)round(movePilotData->heading),currentSpeed,movePilotData->climb,uint8_t(movePilotData->aircraftType));
+    snprintf(buffer,size,"$PFLAA,0,%d,%d,%d,%d,%s,%d,,%d,%.01f,%X,%d",(int32_t)round(relNorth),(int32_t)round(relEast),(int32_t)round(relVert),movePilotData->addressType, movePilotData->DevId.c_str(),(int32_t)round(movePilotData->heading),(int32_t)currentSpeed,movePilotData->climb,uint8_t(movePilotData->aircraftType), movePilotData->noTrack);
     return addChecksum(buffer,size);
     //String movingpilotData = "$PFLAA,0," + String((int32_t)round(relNorth)) + "," + String((int32_t)round(relEast)) + "," + String((int32_t)round(relVert)) + ",2," +
     //		                    movePilotData->DevId + "," + (int32_t)round(movePilotData->heading) + ",0,"  +
@@ -118,7 +118,7 @@ String Flarm::writeFlarmData(FlarmtrackingData *myData,FlarmtrackingData *movePi
 
 int FlarmDataPort::writeDataPort(char *buffer, size_t size){
     if (neighbors > 99) neighbors = 99; //no more then 99 neighbors
-    snprintf(buffer,size,"$PFLAU,%d,1,%d,1,0,0,0,0,0",neighbors,GPSState);
+    snprintf(buffer,size,"$PFLAU,%d,1,%d,1,0,,0,,,",neighbors,GPSState);
     return addChecksum(buffer,size);
     //Serial.printf("length=%d\r\n",strlen(buffer));
 }
@@ -138,7 +138,7 @@ int FlarmDataPort::addChecksum(char *buffer, size_t size){
 }
 
 int FlarmDataPort::writeVersion(char *buffer, size_t size){
-    snprintf(buffer,size,"$PFLAV,A,1.00,1.00,GXAircom");
+    snprintf(buffer,size,"$PFLAV,A,1.00,1.00,"); //no obstacle database
     return addChecksum(buffer,size);
 }
 

--- a/lib/FLARM/FlarmDataPort.h
+++ b/lib/FLARM/FlarmDataPort.h
@@ -42,6 +42,7 @@ typedef struct {
   float speed; //km/h
   float climb; //m/s
   float heading; //deg
+  bool noTrack; //no online tracking
 } FlarmtrackingData;
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3922,6 +3922,13 @@ void checkReceivedLine(const char *ch_str){
     // Handle request for configuration request
     writePGXCFSentence();
     return;
+  }else if (!strncmp(ch_str,"$PFLAC,R,RADIOID",16)){
+    // Handle request ID
+    char buffer[MAXSTRING];
+    snprintf(buffer,MAXSTRING,"$PFLAC,A,RADIOID,%d,%s", MyFanetData.addressType, fanet.getMyDevId().c_str());
+    int pos = flarmDataPort.addChecksum(buffer,MAXSTRING);
+    sendData2Client(buffer, pos);
+    return;
   }else if (!strncmp(ch_str,"$PGXCF,",7)){
     // Handle configuration setting
     readPGXCFSentence(ch_str);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -842,6 +842,7 @@ void sendFlarmData(uint32_t tAct){
           tFanetData.lat = fanet.neighbours[i].lat;
           tFanetData.lon = fanet.neighbours[i].lon;
           tFanetData.speed = fanet.neighbours[i].speed;
+          tFanetData.OnlineTracking = fanet.neighbours[i].OnlineTracking;
           Fanet2FlarmData(&tFanetData,&PilotFlarmData);
           char sOut[MAXSTRING];
           int pos = flarmDataPort.writeFlarmData(sOut,MAXSTRING,&myFlarmData,&PilotFlarmData);
@@ -3289,7 +3290,7 @@ void taskBaro(void *pvParameters){
   #ifdef S3CORE
   uint8_t baroSensor = baro.begin(pI2cOne,&xI2C1Mutex);
   #else
-  pI2cZero->begin(PinBaroSDA,PinBaroSCL,400000); //init i2c
+  pI2cZero->begin(PinBaroSDA,PinBaroSCL,400000u); //init i2c
   uint8_t baroSensor = baro.begin(pI2cZero,&xI2C0Mutex);
   #endif
   baro.setKalmanSettings(setting.vario.sigmaP,setting.vario.sigmaA);
@@ -4060,6 +4061,7 @@ void Fanet2FlarmData(FanetLora::trackingData *FanetData,FlarmtrackingData *Flarm
   FlarmDataData->lon = FanetData->lon;
   FlarmDataData->speed = FanetData->speed;
   FlarmDataData->addressType = (FanetData->addressType) & 0x7F; //clear highest bit (is set for FANET-Msg)
+  FlarmDataData->noTrack = !FanetData->OnlineTracking;
 }
 
 void sendLXPW(uint32_t tAct){
@@ -4477,6 +4479,7 @@ void taskStandard(void *pvParameters){
   
   tFanetData.rssi = 0;
   MyFanetData.rssi = 0;
+  MyFanetData.OnlineTracking = true; //this could be a setting
 
   GxMqtt *pMqtt = NULL;
   static uint8_t myWdCount = 0;
@@ -5060,7 +5063,7 @@ void taskStandard(void *pvParameters){
               if (fanet.onGround){
                 ogn.sendGroundTrackingData(now(),status.gps.Lat,status.gps.Lon,status.gps.alt,fanet.getDevId(tFanetData.devId),fanet.state,MyFanetData.addressType,0.0);
               }else{
-                ogn.sendTrackingData(now(),status.gps.Lat,status.gps.Lon,status.gps.alt,status.gps.speed,MyFanetData.heading,status.vario.ClimbRate,fanet.getMyDevId() ,(Ogn::aircraft_t)fanet.getFlarmAircraftType(&MyFanetData),MyFanetData.addressType,fanet.doOnlineTracking,0.0);
+                ogn.sendTrackingData(now(),status.gps.Lat,status.gps.Lon,status.gps.alt,status.gps.speed,MyFanetData.heading,status.vario.ClimbRate,fanet.getMyDevId() ,(Ogn::aircraft_t)fanet.getFlarmAircraftType(&MyFanetData),MyFanetData.addressType,MyFanetData.OnlineTracking,0.0);
               }
               
             } 


### PR DESCRIPTION
These are 3 small commits that:
* align dataport messages with flarm specs
* Add `no_track` flag (xctrack won't show the glider type correct without this, will also create a bug report there)
* Handle ID request (`$PFLAC,R,RADIOID`), used by XCTrack to connect own ID to xcontest livetracking
* Always set address type = 2 for fanet messages. no need to filter for specific manufacturer ids.